### PR TITLE
mesa: Re-enable the radeonsi driver

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -12,8 +12,6 @@ PACKAGECONFIG_append = " gbm egl gles dri ${MESA_CRYPTO} \
 PACKAGECONFIG_x86 = " egl gles gbm dri dri3 x11 xa r600 gallium gallium-llvm "
 PACKAGECONFIG_x86-64 = " egl gles gbm dri dri3 x11 xa r600 gallium gallium-llvm "
 
-GALLIUMDRIVERS_LLVM33 = "${@bb.utils.contains('PACKAGECONFIG', 'r600', 'r600', '', d)}"
-
 GALLIUMDRIVERS_append_armv7a = ",freedreno"
 GALLIUMDRIVERS_append_aarch64 = ",freedreno"
 


### PR DESCRIPTION
Both meta-backports and openembedded-core uses "radeonsi,r600"
with a single PACKAGECONFIG[r600] knob.