### PR TITLE
kodi 18: limit injection of -DWITH_ARCH to mips* targets

### DIFF
--- a/recipes-multimedia/kodi/kodi_18.bb
+++ b/recipes-multimedia/kodi/kodi_18.bb
@@ -130,14 +130,14 @@ LDFLAGS_append_mipsel = " -latomic"
 LDFLAGS_append_mips64 = " -latomic"
 LDFLAGS_append_mips64el = " -latomic"
 
-KODI_ARCH ?= ""
-KODI_ARCH_mips ?= "${TARGET_ARCH}"
-KODI_ARCH_mipsel ?= "${TARGET_ARCH}"
-KODI_ARCH_mips64 ?= "${TARGET_ARCH}"
-KODI_ARCH_mips64el ?= "${TARGET_ARCH}"
+KODI_ARCH = ""
+KODI_ARCH_mips = "-DWITH_ARCH=${TARGET_ARCH}"
+KODI_ARCH_mipsel = "-DWITH_ARCH=${TARGET_ARCH}"
+KODI_ARCH_mips64 = "-DWITH_ARCH=${TARGET_ARCH}"
+KODI_ARCH_mips64el = "-DWITH_ARCH=${TARGET_ARCH}"
 
 EXTRA_OECMAKE = " \
-    -DWITH_ARCH=${KODI_ARCH} \
+    ${KODI_ARCH} \
     \
     -DNATIVEPREFIX=${STAGING_DIR_NATIVE}${prefix} \
     -DJava_JAVA_EXECUTABLE=/usr/bin/java \


### PR DESCRIPTION
Only for mips it is necessary to specify the arch.
Other platforms are managed by the scripts.

It is unnecessary to pass -DWITH_CPU, besidess this could
make the recipe machine-specific.
This can be done in a separate .bbappend for each machine,
tainted by the proprietary drivers.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>