### PR TITLE
libfmt

### DIFF
--- a/recipes-support/fmt/files/0001-CMakeLists.txt-fix-library-install-path.patch
+++ b/recipes-support/fmt/files/0001-CMakeLists.txt-fix-library-install-path.patch
@@ -1,0 +1,20 @@
+--- a/fmt/CMakeLists.txt	2018-12-29 20:09:19.097507664 +0100
++++ b/fmt/CMakeLists.txt	2018-12-29 20:10:37.085310313 +0100
+@@ -50,7 +50,7 @@
+ # Install targets.
+ if (FMT_INSTALL)
+   include(CMakePackageConfigHelpers)
+-  set(FMT_CMAKE_DIR lib/cmake/fmt CACHE STRING
++  set(FMT_CMAKE_DIR ${BASE_LIB_PATH}/cmake/fmt CACHE STRING
+     "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
+   set(version_config ${PROJECT_BINARY_DIR}/fmt-config-version.cmake)
+   set(project_config ${PROJECT_BINARY_DIR}/fmt-config.cmake)
+@@ -61,7 +61,7 @@
+     set(INSTALL_TARGETS ${INSTALL_TARGETS} fmt-header-only)
+   endif ()
+ 
+-  set(FMT_LIB_DIR lib CACHE STRING
++  set(FMT_LIB_DIR ${BASE_LIB_PATH} CACHE STRING
+     "Installation directory for libraries, relative to ${CMAKE_INSTALL_PREFIX}.")
+ 
+   # Generate the version, config and target files into the build directory.

--- a/recipes-support/fmt/libfmt_git.bb
+++ b/recipes-support/fmt/libfmt_git.bb
@@ -4,7 +4,9 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=c2e38bc8629eac247a73b65c1548b2f0"
 
 PV = "4.0.0"
-SRC_URI = "git://github.com/fmtlib/fmt.git;protocol=https"
+SRC_URI = "git://github.com/fmtlib/fmt.git;protocol=https \
+    file://0001-CMakeLists.txt-fix-library-install-path.patch \
+"
 SRCREV = "d16c4d20f88c738d79ecec7c355584f7e161e03e"
 
 S = "${WORKDIR}/git"
@@ -12,3 +14,5 @@ S = "${WORKDIR}/git"
 inherit cmake
 
 FILES_${PN}-dev += "${libdir}/cmake"
+
+EXTRA_OECMAKE = "-DBASE_LIB_PATH=${baselib}"


### PR DESCRIPTION
The library install path may be /usr/lib64 rather
than fixed /usr/lib. Provide a variable to make it
could override by cmake command line.