### PR TITLE
layer: make systemd more optional, additional variable to turn off kodi autostart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-Meta-kodi
-================================
+# Meta-kodi
 
-Introduction
--------------------------
+## Introduction
 
 The official OpenEmbedded/Yocto Project layer for Kodi
 
@@ -10,22 +8,32 @@ The meta-kodi layer depends on:
 
 	URI: git://git.openembedded.org/openembedded-core
 	layers: meta
-	branch: daisy
+	branch: zeus
 
 	URI: git://git.openembedded.org/meta-openembedded
-	layers: meta-oe
-	branch: daisy
+	layers: meta-oe, meta-multimedia, meta-networking, meta-python
+	branch: zeus
 
 Please follow the recommended setup procedures of your OE distribution. For Angstrom that is http://www.angstrom-distribution.org/building-angstrom, other distros should have similar online resources.
 
+## Customization
 
-Contributing
--------------------------
+There is a list of variables that can be used in your local.conf or distro.conf to customize behavior
+
+**KODI_SYSTEMD_AUTOSTART** - If your distribution is shipped with systemd support then
+*kodi-systemd-service* recipe will be installed automatically by kodi. By default **KODI_SYSTEMD_AUTOSTART**
+variable is set to "enable" and this will trigger autostart kodi behavior. It can be changed to "disable" 
+in oder to disable autostart feature.
+
+## Init manager
+
+We strongly suggesting to use systemd as init manager. Sysvinit is untested and may not work properly.
+
+## Contributing
 
 Please use github for pull requests: https://github.com/koenkooi/meta-kodi/pulls
 
-Reporting bugs
--------------------------
+## Reporting bugs
 
 The github issue tracker (https://github.com/koenkooi/meta-kodi/issues) is being used to keep track of bugs.
 

--- a/classes/kodi-common.bbclass
+++ b/classes/kodi-common.bbclass
@@ -16,3 +16,7 @@ KODI_GRAPHICAL_BACKEND ?= "gbm"
 # Codecs
 
 KODI_ADDITIONAL_CODES ?= "vidstab x265" 
+
+# Autostart
+
+KODI_SYSTEMD_AUTOSTART ?= "enable"

--- a/recipes-multimedia/kodi-systemd-service/kodi-systemd-service.bb
+++ b/recipes-multimedia/kodi-systemd-service/kodi-systemd-service.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Kodi Media Center systemd service"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit kodi-common systemd
+
+PREFFERED_KODI_SERVICE ?= "kodi-${@bb.utils.contains('KODI_GRAPHICAL_BACKEND', 'x11', 'x11', 'gbm', d)}.service"
+
+SRC_URI = "file://${PREFFERED_KODI_SERVICE}"
+
+SYSTEMD_SERVICE_${PN} = "${PREFFERED_KODI_SERVICE}"
+SYSTEMD_AUTO_ENABLE_${PN} = "${KODI_SYSTEMD_AUTOSTART}"
+
+FILES_${PN} = "${systemd_unitdir}/system"
+
+do_install() {
+	install -d ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/${PREFFERED_KODI_SERVICE} ${D}${systemd_unitdir}/system/
+}

--- a/recipes-multimedia/kodi-systemd-service/kodi-systemd-service/kodi-gbm.service
+++ b/recipes-multimedia/kodi-systemd-service/kodi-systemd-service/kodi-gbm.service
@@ -1,8 +1,7 @@
 [Unit]
-Description=Kodi media thing
+Description=Kodi Media Center
 
 [Service]
-
 Environment=__GL_YIELD=USLEEP
 Environment=DISPLAY=:0.0
 Environment=WAYLAND_DISPLAY=wayland-0

--- a/recipes-multimedia/kodi-systemd-service/kodi-systemd-service/kodi-x11.service
+++ b/recipes-multimedia/kodi-systemd-service/kodi-systemd-service/kodi-x11.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Kodi media thing
+Description=Kodi Media Center
 
 [Service]
 User=root

--- a/recipes-multimedia/kodi/kodi.inc
+++ b/recipes-multimedia/kodi/kodi.inc
@@ -1,5 +1,3 @@
-FILESPATH =. "${FILE_DIRNAME}/kodi-18:"
-
 CODENAME ?= "Leia"
 
 # Some forked meta-kodi repositories using custom kodi urls, personally I think they should use variable instead of


### PR DESCRIPTION
With this PR:
* systemd is more optional
* kodi autostart can be disabled by setting **KODI_SYSTEMD_AUTOSTART** to "disable"
* there is expanded and updated documentation about current requirements and variables.

Updated documentation can be quickly viewed here:
https://github.com/dev-0x7C6/meta-kodi/blob/zeus/README.md
