### PR TITLE
kodi: added vaapi and vdpau support.

### DIFF
--- a/classes/kodi-common.bbclass
+++ b/classes/kodi-common.bbclass
@@ -1,13 +1,7 @@
-# Should we create notice to inform users that do not want X11 support and get vdpau support?
+#Acceleration
 
-KODIACCELERATIONLIBRARIESX86DEFAULTS ?= " \
-  ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'vdpau', '', d)} \
-  ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'vaapi', '', d)} \
-"
-
-KODIACCELERATIONLIBRARIES ?= ""
-KODIACCELERATIONLIBRARIES_x86 = "${KODIACCELERATIONLIBRARIESX86DEFAULTS}"
-KODIACCELERATIONLIBRARIES_x86-64 = "${KODIACCELERATIONLIBRARIESX86DEFAULTS}"
+VAAPISUPPORT ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', '1', '0', d)}"
+VDPAUSUPPORT ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '1', '0', d)}"
 
 # Variables
 
@@ -16,10 +10,6 @@ KODICODENAME ?= "Leia"
 # Default to GBM everywhere, sucks to be nvidia
 
 KODIGRAPHICALBACKEND ?= "gbm"
-
-# Codecs
-
-KODIADDITIONALCODECS ?= "vidstab x265" 
 
 # Autostart
 

--- a/classes/kodi-common.bbclass
+++ b/classes/kodi-common.bbclass
@@ -1,8 +1,3 @@
-#Acceleration
-
-VAAPISUPPORT ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', '1', '0', d)}"
-VDPAUSUPPORT ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '1', '0', d)}"
-
 # Variables
 
 KODICODENAME ?= "Leia"

--- a/classes/vpu.bbclass
+++ b/classes/vpu.bbclass
@@ -1,0 +1,2 @@
+VAAPISUPPORT ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', '1', '0', d)}"
+VDPAUSUPPORT ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '1', '0', d)}"

--- a/recipes-devtools/pugixml/pugixml_%.bbappend
+++ b/recipes-devtools/pugixml/pugixml_%.bbappend
@@ -1,0 +1,4 @@
+inherit native
+
+EXTRA_OECMAKE += "-DBUILD_PKGCONFIG=ON"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-graphics/libva/libva_%.bbappend
+++ b/recipes-graphics/libva/libva_%.bbappend
@@ -1,0 +1,1 @@
+DEPENDS_remove = "virtual/mesa"

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -12,4 +12,3 @@ PACKAGES += "libvdpau-mesa libvdpau-mesa-dev"
 
 FILES_libvdpau-mesa = "${libdir}/vdpau/*.so.*"
 FILES_libvdpau-mesa-dev = "${libdir}/vdpau/*.so"
-

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,0 +1,15 @@
+inherit kodi-common
+
+PACKAGECONFIG_append_class-target = " \
+    ${@bb.utils.contains('VAAPISUPPORT', '1', 'vaapi', '', d)} \
+    ${@bb.utils.contains('VDPAUSUPPORT', '1', 'vdpau', '', d)} \
+"
+
+PACKAGECONFIG[vaapi] = "-Dgallium-va=true, -Dgallium-va=false,libva"
+PACKAGECONFIG[vdpau] = "-Dgallium-vdpau=true, -Dgallium-vdpau=false,libvdpau"
+
+PACKAGES += "libvdpau-mesa libvdpau-mesa-dev"
+
+FILES_libvdpau-mesa = "${libdir}/vdpau/*.so.*"
+FILES_libvdpau-mesa-dev = "${libdir}/vdpau/*.so"
+

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,4 +1,4 @@
-inherit kodi-common
+inherit vpu
 
 PACKAGECONFIG_append_class-target = " \
     ${@bb.utils.contains('VAAPISUPPORT', '1', 'vaapi', '', d)} \

--- a/recipes-graphics/wayland/wayland_%.bbappend
+++ b/recipes-graphics/wayland/wayland_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF_remove_class-native = "--disable-libraries"

--- a/recipes-graphics/waylandpp/waylandpp_0.2.7.bb
+++ b/recipes-graphics/waylandpp/waylandpp_0.2.7.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Wayland C++ bindings"
+HOMEPAGE = "https://nilsbrause.github.io/waylandpp_docs"
+BUGTRACKER = "https://github.com/NilsBrause/waylandpp/issues"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7f6b13e4480850c59e176edd427d996e"
+
+SRCREV = "${PV}"
+SRC_URI = "git://github.com/NilsBrause/waylandpp.git;protocol=https"
+S = "${WORKDIR}/git"
+
+inherit cmake lib_package native pkgconfig
+
+DEPENDS += "doxygen-native wayland pugixml"
+
+DEPENDS_class-native += "wayland-native pugixml-native"
+DEPENDS_class-target += "waylandpp-native"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
+++ b/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
@@ -3,4 +3,11 @@ inherit kodi-common
 PACKAGECONFIG[vidstab] = "--enable-libvidstab,--disable-libvidstab,vid.stab"
 PACKAGECONFIG[x265] = "--enable-libx265,--disable-libx265,x265"
 
-PACKAGECONFIG_append = " ${KODIADDITIONALCODECS} ${KODIACCELERATIONLIBRARIES}"
+KODIFFMPEGADDITIONALS ?= " \
+    ${@bb.utils.contains('VAAPISUPPORT', '1', 'vaapi', '', d)} \
+    ${@bb.utils.contains('VDPAUSUPPORT', '1', 'vdpau', '', d)} \
+    vidstab \
+    x265 \
+"
+
+PACKAGECONFIG_append = " ${KODIFFMPEGADDITIONALS}"

--- a/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
+++ b/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
@@ -1,4 +1,4 @@
-inherit kodi-common
+inherit vpu
 
 PACKAGECONFIG[vidstab] = "--enable-libvidstab,--disable-libvidstab,vid.stab"
 PACKAGECONFIG[x265] = "--enable-libx265,--disable-libx265,x265"

--- a/recipes-multimedia/kodi/kodi.inc
+++ b/recipes-multimedia/kodi/kodi.inc
@@ -1,7 +1,7 @@
 # Some forked meta-kodi repositories using custom kodi urls, personally I think they should use variable instead of
 # creating different recipes and diverse from upstream
 
-inherit kodi-common
+inherit kodi-common vpu
 
 KODIURI ?= "gitsm://github.com/xbmc/xbmc.git;protocol=https;branch=${KODICODENAME}"
 KODIREV ?= "${PV}-${KODICODENAME}"

--- a/recipes-multimedia/kodi/kodi_18.6.bb
+++ b/recipes-multimedia/kodi/kodi_18.6.bb
@@ -86,7 +86,7 @@ PACKAGECONFIG ?= " \
   ${@bb.utils.contains('VAAPISUPPORT', '1', 'vaapi', '', d)} \
   ${@bb.utils.contains('VDPAUSUPPORT', '1', 'vdpau', '', d)} \
   ${@bb.utils.filter('DISTRO_FEATURES', 'bluetooth pulseaudio systemd', d)} \
-  ${@bb.utils.filter('KODIGRAPHICALBACKEND', 'amlogic gbm raspberrypi wayland x11', d)} \
+  ${@bb.utils.filter('KODIGRAPHICALBACKEND', 'gbm wayland x11', d)} \
   airtunes \
   lcms \
   lirc \
@@ -94,9 +94,7 @@ PACKAGECONFIG ?= " \
 
 # Core windowing system choices
 
-PACKAGECONFIG[amlogic] = "-DCORE_PLATFORM_NAME=aml,,"
 PACKAGECONFIG[gbm] = "-DCORE_PLATFORM_NAME=gbm -DGBM_RENDER_SYSTEM=gles,,"
-PACKAGECONFIG[raspberrypi] = "-DCORE_PLATFORM_NAME=rbpi,,userland"
 PACKAGECONFIG[wayland] = "-DCORE_PLATFORM_NAME=wayland -DWAYLAND_RENDER_SYSTEM=gles,,wayland waylandpp"
 PACKAGECONFIG[x11] = "-DCORE_PLATFORM_NAME=x11,,libxinerama libxmu libxrandr libxtst glew"
 

--- a/recipes-multimedia/kodi/kodi_18.6.bb
+++ b/recipes-multimedia/kodi/kodi_18.6.bb
@@ -78,11 +78,15 @@ DEPENDS += " \
 CCACHE_DISABLE = "1"
 ASNEEDED = ""
 
+KODIVAAPIDEPENDS = "libva"
+KODIVAAPIDEPENDS_append_x86 = " intel-vaapi-driver"
+KODIVAAPIDEPENDS_append_x86-64 = " intel-vaapi-driver"
 
 PACKAGECONFIG ?= " \
-  ${KODIACCELERATIONLIBRARIES} \
-  ${KODIGRAPHICALBACKEND} \
+  ${@bb.utils.contains('VAAPISUPPORT', '1', 'vaapi', '', d)} \
+  ${@bb.utils.contains('VDPAUSUPPORT', '1', 'vdpau', '', d)} \
   ${@bb.utils.filter('DISTRO_FEATURES', 'bluetooth pulseaudio systemd', d)} \
+  ${@bb.utils.filter('KODIGRAPHICALBACKEND', 'amlogic gbm raspberrypi wayland x11', d)} \
   airtunes \
   lcms \
   lirc \
@@ -107,8 +111,8 @@ PACKAGECONFIG[mysql] = "-DENABLE_MYSQLCLIENT=ON,-DENABLE_MYSQLCLIENT=OFF,mysql5"
 PACKAGECONFIG[optical] = "-DENABLE_OPTICAL=ON,-DENABLE_OPTICAL=OFF"
 PACKAGECONFIG[pulseaudio] = "-DENABLE_PULSEAUDIO=ON,-DENABLE_PULSEAUDIO=OFF,pulseaudio"
 PACKAGECONFIG[systemd] = ",,,kodi-systemd-service"
-PACKAGECONFIG[vaapi] = "-DENABLE_VAAPI=ON,-DENABLE_VAAPI=OFF,libva"
-PACKAGECONFIG[vdpau] = "-DENABLE_VDPAU=ON,-DENABLE_VDPAU=OFF,libvdpau"
+PACKAGECONFIG[vaapi] = "-DENABLE_VAAPI=ON,-DENABLE_VAAPI=OFF,${KODIVAAPIDEPENDS},${KODIVAAPIDEPENDS}"
+PACKAGECONFIG[vdpau] = "-DENABLE_VDPAU=ON,-DENABLE_VDPAU=OFF,libvdpau,libvdpau-mesa"
 
 # Compilation tunes
 


### PR DESCRIPTION
I have positive logs from kodi that vaapi library is loaded correctly. Seems that vaapi is preferred video acceleration method - mesa is shipping multiple drivers compatible with vaapi.

Added:
**VAAPISUPPORT** is on when opengl flag is set in **DISTRO_FEATURES** (this is based on libva restrictions)

**VDPAUSUPPORT** is on when x11 flag is set in **DISTRO_FEATURES** (this is based on libvdpau restrictions)

Removed:
**KODIACCELERATIONLIBRARIESX86DEFAULTS**, **KODIADDITIONALCODECS**.

**KODIGRAPHICALBACKEND** choice is now filtered by supported flags.
