### PR TITLE
Upgrade to Kodi 18.6 and support Yocto release Dunfell and Zeus

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,5 +8,5 @@ BBFILE_COLLECTIONS += "meta-kodi"
 BBFILE_PATTERN_meta-kodi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-kodi = "8"
 
-LAYERDEPENDS_meta-kodi = "networking-layer multimedia-layer meta-python core openembedded-layer"
-LAYERSERIES_COMPAT_meta-kodi = "sumo thud warrior"
+LAYERDEPENDS_meta-kodi = "networking-layer multimedia-layer meta-python meta-python2 core openembedded-layer"
+LAYERSERIES_COMPAT_meta-kodi = "zeus dunfell"

--- a/recipes-multimedia/kodi/kodi_18.bb
+++ b/recipes-multimedia/kodi/kodi_18.bb
@@ -69,12 +69,12 @@ DEPENDS += " \
             zlib \
           "
 
-SRCREV = "3ade758ceb0f8fe6d0cb7f2dcd758c873c80cb1f"
+SRCREV = "8e967df9218279618bcbfa8a898d8f80f7b4e449"
 
 # 'patch' doesn't support binary diffs
 PATCHTOOL = "git"
 
-PV = "18.4+git${SRCPV}"
+PV = "18.6+git${SRCPV}"
 SRC_URI = "git://github.com/xbmc/xbmc.git;protocol=https;branch=Leia \
            \
            file://0001-Add-support-for-musl-triplets.patch \

--- a/recipes-support/libffi/libffi_3.2.1.bbappend
+++ b/recipes-support/libffi/libffi_3.2.1.bbappend
@@ -1,4 +1,0 @@
-do_install_append() {
-    install -d ${D}${includedir}
-    install -m 0644 ${B}/include/ffi.h ${D}${includedir}
-}


### PR DESCRIPTION
Hi,

This GitHub pull request includes the following changes:

* Add support for Yocto releases Zeus and Dunfell, including requirement for meta-python2 which provides `classes/python-dir.bbclass`
* Apply libffi bbappend to newer versions
* Upgrade Kodi to to the latest stable relase "Leia" 18.6

Tested on Raspberry Pi 3 and verified it builds for QEMUx86-64.

Best regards,
Leon