### PR TITLE
kodi_18: simplify mips overrides, fix CMake linking error

### DIFF
--- a/recipes-multimedia/kodi/kodi_18.bb
+++ b/recipes-multimedia/kodi/kodi_18.bb
@@ -130,21 +130,7 @@ PACKAGECONFIG[mysql] = "-DENABLE_MYSQLCLIENT=ON,-DENABLE_MYSQLCLIENT=OFF,mysql5"
 PACKAGECONFIG[pulseaudio] = "-DENABLE_PULSEAUDIO=ON,-DENABLE_PULSEAUDIO=OFF,pulseaudio"
 PACKAGECONFIG[lcms] = ",,lcms"
 
-LDFLAGS += "${TOOLCHAIN_OPTIONS}"
-LDFLAGS_append_mips = " -latomic"
-LDFLAGS_append_mipsel = " -latomic"
-LDFLAGS_append_mips64 = " -latomic"
-LDFLAGS_append_mips64el = " -latomic"
-
-KODI_ARCH = ""
-KODI_ARCH_mips = "-DWITH_ARCH=${TARGET_ARCH}"
-KODI_ARCH_mipsel = "-DWITH_ARCH=${TARGET_ARCH}"
-KODI_ARCH_mips64 = "-DWITH_ARCH=${TARGET_ARCH}"
-KODI_ARCH_mips64el = "-DWITH_ARCH=${TARGET_ARCH}"
-
 EXTRA_OECMAKE = " \
-    ${KODI_ARCH} \
-    \
     -DNATIVEPREFIX=${STAGING_DIR_NATIVE}${prefix} \
     -DJava_JAVA_EXECUTABLE=/usr/bin/java \
     -DWITH_TEXTUREPACKER=${STAGING_BINDIR_NATIVE}/TexturePacker \
@@ -169,6 +155,10 @@ EXTRA_OECMAKE = " \
     -DENABLE_DEBUGFISSION=OFF \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 "
+EXTRA_OECMAKE_append_mipsarch = " -DWITH_ARCH=${TARGET_ARCH}"
+
+LDFLAGS += "${TOOLCHAIN_OPTIONS}"
+LDFLAGS_append_mipsarch = " -latomic -lpthread"
 
 # OECMAKE_GENERATOR="Unix Makefiles"
 #PARALLEL_MAKE = " "


### PR DESCRIPTION
This happens with kodi 18.9 on vuduo2 using bfd or gold:

CMakeError.log
 ...
 [2/2] Linking C executable cmTC_1ac7c
 FAILED: cmTC_1ac7c
 ...
 ld.gold: error: cannot find -lpthreads
 ...
 error: undefined reference to 'pthread_create'
 collect2: error: ld returned 1 exit status
 ninja: build stopped: subcommand failed.

As seen in OpenPLi as of commit-id dc55339

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>