### PR TITLE
kodi: remove libsquish dependency

### DIFF
--- a/recipes-multimedia/kodi/kodi_git.bb
+++ b/recipes-multimedia/kodi/kodi_git.bb
@@ -60,7 +60,6 @@ DEPENDS += " \
   libpcre \
   libplist \
   libsamplerate0 \
-  libsquish \
   libssh \
   libtinyxml \
   libusb1 \


### PR DESCRIPTION
libsquish has been dropped in kodi

https://github.com/xbmc/xbmc/commit/ed03f828be3615d294eb4a4cfccc5cdccec22997
https://github.com/xbmc/xbmc/commit/7d9b190a0a87a23ad2108889b20840be9b759fb8