### PR TITLE
kodi: fix crossguid patch

### DIFF
--- a/recipes-multimedia/kodi/kodi/0001-FindCrossGUID.cmake-fix-for-crossguid-0.2.2.patch
+++ b/recipes-multimedia/kodi/kodi/0001-FindCrossGUID.cmake-fix-for-crossguid-0.2.2.patch
@@ -1,16 +1,16 @@
-From e49217dce4cf400e3da7cf403d146b29220fc5f6 Mon Sep 17 00:00:00 2001
+From ba6b455037322f73cbc8cd551d94eab7ff61867e Mon Sep 17 00:00:00 2001
 From: Markus Volk <f_l_k@t-online.de>
-Date: Wed, 14 Jul 2021 16:24:32 +0200
-Subject: [PATCH] FindCrossGUID.cmake: fix for crossguid 0.2.x
+Date: Sun, 25 Jul 2021 23:17:10 +0200
+Subject: [PATCH] FindCrossGUID.cmake: fix for crossguid 0.2.2
 
 Signed-off-by: Markus Volk <f_l_k@t-online.de>
 ---
- cmake/modules/FindCrossGUID.cmake | 6 +++---
- xbmc/utils/StringUtils.cpp        | 3 ++-
- 2 files changed, 5 insertions(+), 4 deletions(-)
+ cmake/modules/FindCrossGUID.cmake | 8 ++++----
+ xbmc/utils/StringUtils.cpp        | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/cmake/modules/FindCrossGUID.cmake b/cmake/modules/FindCrossGUID.cmake
-index 613c2a4a3fd..1ce696f954c 100644
+index 613c2a4a3f..f4f78b3912 100644
 --- a/cmake/modules/FindCrossGUID.cmake
 +++ b/cmake/modules/FindCrossGUID.cmake
 @@ -46,10 +46,10 @@ if(ENABLE_INTERNAL_CROSSGUID)
@@ -27,15 +27,22 @@ index 613c2a4a3fd..1ce696f954c 100644
  
    include(SelectLibraryConfigurations)
    select_library_configurations(CROSSGUID)
+@@ -62,7 +62,7 @@ else()
+     set(CROSSGUID_LIBRARIES ${CROSSGUID_LIBRARY})
+     set(CROSSGUID_INCLUDE_DIRS ${CROSSGUID_INCLUDE_DIR})
+ 
+-    if(EXISTS "${CROSSGUID_INCLUDE_DIR}/guid.hpp")
++    if(EXISTS "${CROSSGUID_INCLUDE_DIR}/Guid.hpp")
+       set(CROSSGUID_DEFINITIONS -DHAVE_NEW_CROSSGUID)
+     endif()
+ 
 diff --git a/xbmc/utils/StringUtils.cpp b/xbmc/utils/StringUtils.cpp
-index c19d285bba6..1449378f8d6 100644
+index c19d285bba..cb084ed84f 100644
 --- a/xbmc/utils/StringUtils.cpp
 +++ b/xbmc/utils/StringUtils.cpp
-@@ -16,8 +16,9 @@
- //
+@@ -17,7 +17,7 @@
  //------------------------------------------------------------------------
  
-+#define HAVE_NEW_CROSSGUID
  #ifdef HAVE_NEW_CROSSGUID
 -#include <guid.hpp>
 +#include <Guid.hpp>

--- a/recipes-multimedia/kodi/kodi_git.bb
+++ b/recipes-multimedia/kodi/kodi_git.bb
@@ -11,7 +11,7 @@ require ${BPN}.inc
 inherit cmake gettext python3-dir python3native
 
 SRC_URI_append = " \
-	file://0001-FindCrossGUID.cmake-fix-for-crossguid-0.2.x.patch \
+	file://0001-FindCrossGUID.cmake-fix-for-crossguid-0.2.2.patch \
 "
 
 OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"


### PR DESCRIPTION
overlooked, that we already have a place where HAVE_NEW_CROSSGUID should have
been set automatically