### PR TITLE
kodi: add missing autotools dependencies

### DIFF
--- a/recipes-multimedia/kodi/kodi_git.bb
+++ b/recipes-multimedia/kodi/kodi_git.bb
@@ -17,6 +17,8 @@ SRC_URI:append = " \
 OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
 
 DEPENDS += " \
+  autoconf-native \
+  automake-native \
   curl-native \
   flatbuffers-native \
   googletest-native \
@@ -48,9 +50,6 @@ DEPENDS += " \
   libass \
   libcdio \
   libcec \
-  libdvdcss \
-  libdvdnav \
-  libdvdread \
   libinput \
   libmad \
   libmicrohttpd \


### PR DESCRIPTION
Kodi builds libdvdnav and libdvdread internally using autotools.
After the following commit we need to explicitly add them to DEPENDS
or the build will fail.

https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?h=master-next&id=04b37f914ed10caf8e24c58cd67fd508cd95fd6d

Remove the unused external libdvd from DEPENDS

Signed-off-by: MarkusVolk <f_l_k@t-online.de>