### PR TITLE
fstrcmp: remove LIBTOOL prefix

### DIFF
--- a/recipes-support/fstrcmp/fstrcmp_0.7.bb
+++ b/recipes-support/fstrcmp/fstrcmp_0.7.bb
@@ -16,6 +16,4 @@ inherit autotools-brokensep manpages
 
 DEPENDS = "groff-native"
 
-export LIBTOOL = "${HOST_SYS}-libtool"
-
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
As of this commit we need to remove the prefix from LIBTOOL variable
to unbreak the build for master branch

https://git.yoctoproject.org/poky/commit/?id=ebf34d5b252cc9bec3ba97039807e2fa03dcfbe2

This presumably will break build for older poky versions

Signed-off-by: MarkusVolk <f_l_k@t-online.de>