### PR TITLE
kodi: remove unused dependencies

### DIFF
--- a/recipes-multimedia/kodi/kodi_git.bb
+++ b/recipes-multimedia/kodi/kodi_git.bb
@@ -33,13 +33,10 @@ DEPENDS += " \
   zip-native \
   \
   avahi \
-  boost \
   bzip2 \
   crossguid \
   curl \
   dcadec \
-  enca \
-  expat \
   faad2 \
   ffmpeg \
   flatbuffers \
@@ -53,18 +50,14 @@ DEPENDS += " \
   libcdio \
   libcec \
   libinput \
-  libmad \
   libmicrohttpd \
-  libmms \
-  libmodplug \
   libnfs \
   libpcre \
   libplist \
-  libsamplerate0 \
   libssh \
   libtinyxml \
-  libusb1 \
   libxkbcommon \
+  libxml2 \
   libxslt \
   lzo \
   mpeg2dec \
@@ -73,10 +66,8 @@ DEPENDS += " \
   spdlog \
   sqlite3 \
   taglib \
-  udev \
   virtual/egl \
   wavpack \
-  yajl \
   zlib \
 "
 


### PR DESCRIPTION
This will reduce build time and disk usage. Most of these dependencies have been dropped in Kodi.
Expat isn't needed. Build uses expat-native but that is currently pulled in automatically.
Not sure about udev. For systemd builds udev is there automatically. udev is blacklisted for sysvinit. Trying
to depend on it will probably break things for sysvinit because we would need eudev for sysvinit if that really is
a hard dependency for Kodi