### PR TITLE
kodi: allow networking for do_compile

### DIFF
--- a/recipes-multimedia/kodi/kodi_git.bb
+++ b/recipes-multimedia/kodi/kodi_git.bb
@@ -224,3 +224,5 @@ RRECOMMENDS:${PN}:append:libc-glibc = " \
   glibc-charmap-utf-8 \
   glibc-localedata-en-us \
 "
+
+do_compile[network] = "1"


### PR DESCRIPTION
The current poky master disallows networking for all tasks by default.
This commit then enables networking only for tasks that are expected to need it.
https://git.yoctoproject.org/poky/commit/?id=4eea21b7addd091c7e549684699897fe7d60533c&h=master

Kodi fetches libdvd at do_compile, so we need to expicitly allow that.